### PR TITLE
FHIR-15359: Expand UDI mapping coverage to DIM, V2, and SDC

### DIFF
--- a/_updatePublisher.sh
+++ b/_updatePublisher.sh
@@ -33,7 +33,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 echo "Checking internet connection"
-curl -sSf tx.fhir.org > /dev/null
+curl -sS https://tx.fhir.org > /dev/null
 
 if [ $? -ne 0 ] ; then
   echo "Offline (or the terminology server is down), unable to update.  Exiting"

--- a/input/pagecontent/mappingdim.md
+++ b/input/pagecontent/mappingdim.md
@@ -22,27 +22,24 @@ Please refer to the Mappings tab of each profile page for mapping ISO/IEEE 11073
 
 #### Device Identification and Unique Device Identification (UDI)
 
-In ISO/IEEE 11073 DIM, the Medical Device System (MDS) is uniquely identified by:
-- **SystemIdentifier/Identification** consisting of a Root (OID) and Extension that provide a globally unique identifier for the device instance
-- **SystemIdentifier/Model** identifying the device model
-- **SystemIdentifier/SerialNumber** providing the device's serial number
+For DIM-to-FHIR UDI mapping in this guide, use the DIM elements that are mapped in the MDS Device profile:
 
-These components map to FHIR Device resource elements for Unique Device Identification (UDI):
-
-| IEEE 11073 DIM Element | FHIR Device Mapping | Notes |
-| --- | --- | --- |
-| SystemIdentifier/Identification/Root (OID) | `Device.identifier.system` | The OID root identifies the namespace (e.g., manufacturer identifier) |
-| SystemIdentifier/Identification/Extension | `Device.identifier.value` | The extension uniquely identifies the specific device instance within the namespace |
-| SystemIdentifier/Model | `Device.modelNumber` | The device model designation |
-| SystemIdentifier/SerialNumber | `Device.serialNumber` | The device's serial number, a key component of UDI |
-| UDI structured data (where available) | `Device.udiCarrier` | FHIR provides structured storage of UDI barcodes and parsed UDI data |
-| UDI human-readable label | `Device.deviceName` with `type`=`udi-label-name` | The label name from the device's UDI label |
+| IEEE 11073 DIM element (actual mapping source) | FHIR Device mapping |
+| --- | --- |
+| `VMS::System-Id` | `Device.identifier.value` (EUI-64 identifier value) |
+| `VMS::Production-Specification[spec-type=device-identifier]::prod-spec` | `Device.udiCarrier.deviceIdentifier` |
+| `VMS::Udi::udi-issuer` | `Device.udiCarrier.issuer` |
+| `VMS::Udi::udi-authority` | `Device.udiCarrier.jurisdiction` |
+| `VMS::Udi::udi-label` | `Device.udiCarrier.carrierHRF` |
+| `VMS::Production-Specification[spec-type=serial-number]::prod-spec` | `Device.serialNumber` |
+| `VMS::System-Model::manufacturer` | `Device.manufacturer` |
+| `VMS::System-Model::model-number` | `Device.modelNumber` |
 {: .grid}
 
-**Implementation Guidance**: 
-- Device implementations should populate both `Device.identifier` (from IEEE 11073 identifiers) and, where regulatory UDI information is available from the device, `Device.udiCarrier` with the parsed UDI data.
-- The `Device.serialNumber` element is critical for device instance traceability and should always be populated from the DIM SystemIdentifier/SerialNumber.
-- When device identifiers are converted to FHIR, implementers should preserve the IEEE 11073 OID-based namespace in the `identifier.system` to maintain the relationships and traceability defined by the original device model.
+**Implementation Guidance**:
+- Populate `Device.identifier` for the DIM system identity (`VMS::System-Id`) and use `Device.udiCarrier` for explicit UDI elements (`deviceIdentifier`, `issuer`, `jurisdiction`, and `carrierHRF`).
+- Keep `Device.serialNumber` populated from `VMS::Production-Specification[spec-type=serial-number]::prod-spec` for traceability alongside UDI fields.
+- These DIM paths are the authoritative sources for UDI carriage used by this IG's profile mappings.
 
 #### Measurement Status
 Observed values in ISO/IEEE 11073 DIM include a bit field that indicates measurement status. FHIR Observations do not have a single element for this purpose. Instead there is security metadata, dataAbsentReason for missing values, and interpretation to report significance of a result.  

--- a/input/pagecontent/mappingdim.md
+++ b/input/pagecontent/mappingdim.md
@@ -19,6 +19,31 @@ Most object classes in ISO/IEEE 11073 DIM can be mapped to FHIR resources as out
 Please refer to the Mappings tab of each profile page for mapping ISO/IEEE 11073 DIM object attributes to FHIR resource elements.
 
 ### Mapping Details
+
+#### Device Identification and Unique Device Identification (UDI)
+
+In ISO/IEEE 11073 DIM, the Medical Device System (MDS) is uniquely identified by:
+- **SystemIdentifier/Identification** consisting of a Root (OID) and Extension that provide a globally unique identifier for the device instance
+- **SystemIdentifier/Model** identifying the device model
+- **SystemIdentifier/SerialNumber** providing the device's serial number
+
+These components map to FHIR Device resource elements for Unique Device Identification (UDI):
+
+| IEEE 11073 DIM Element | FHIR Device Mapping | Notes |
+| --- | --- | --- |
+| SystemIdentifier/Identification/Root (OID) | `Device.identifier.system` | The OID root identifies the namespace (e.g., manufacturer identifier) |
+| SystemIdentifier/Identification/Extension | `Device.identifier.value` | The extension uniquely identifies the specific device instance within the namespace |
+| SystemIdentifier/Model | `Device.modelNumber` | The device model designation |
+| SystemIdentifier/SerialNumber | `Device.serialNumber` | The device's serial number, a key component of UDI |
+| UDI structured data (where available) | `Device.udiCarrier` | FHIR provides structured storage of UDI barcodes and parsed UDI data |
+| UDI human-readable label | `Device.deviceName` with `type`=`udi-label-name` | The label name from the device's UDI label |
+{: .grid}
+
+**Implementation Guidance**: 
+- Device implementations should populate both `Device.identifier` (from IEEE 11073 identifiers) and, where regulatory UDI information is available from the device, `Device.udiCarrier` with the parsed UDI data.
+- The `Device.serialNumber` element is critical for device instance traceability and should always be populated from the DIM SystemIdentifier/SerialNumber.
+- When device identifiers are converted to FHIR, implementers should preserve the IEEE 11073 OID-based namespace in the `identifier.system` to maintain the relationships and traceability defined by the original device model.
+
 #### Measurement Status
 Observed values in ISO/IEEE 11073 DIM include a bit field that indicates measurement status. FHIR Observations do not have a single element for this purpose. Instead there is security metadata, dataAbsentReason for missing values, and interpretation to report significance of a result.  
 Measurement status information is mapped to `Resource.meta.security`, `Observation.dataAbsentReason` or `Observation.component.dataAbsentReason`, and `Observation.interpretation` or `Observation.component.interpretation` elements. The interpretation value set binding is extended to add relevant codes from the [Measurement status codes](CodeSystem-measurement-status.html) defined in this implementation guide.

--- a/input/pagecontent/mappingdim.md
+++ b/input/pagecontent/mappingdim.md
@@ -26,7 +26,7 @@ For DIM-to-FHIR UDI mapping in this guide, use the DIM elements that are mapped 
 
 | IEEE 11073 DIM element (actual mapping source) | FHIR Device mapping |
 | --- | --- |
-| `VMS::System-Id` | `Device.identifier.value` (EUI-64 identifier value) |
+| `VMS::System-Id` | `Device.identifier.value` (EUI-64 value; `Device.identifier.system` fixed to `urn:oid:1.2.840.10004.1.1.1.0.0.1.0.0.1.2680` in the MDS Device profile) |
 | `VMS::Production-Specification[spec-type=device-identifier]::prod-spec` | `Device.udiCarrier.deviceIdentifier` |
 | `VMS::Udi::udi-issuer` | `Device.udiCarrier.issuer` |
 | `VMS::Udi::udi-authority` | `Device.udiCarrier.jurisdiction` |

--- a/input/pagecontent/mappingsdc.md
+++ b/input/pagecontent/mappingsdc.md
@@ -22,6 +22,35 @@ Please refer to the Mappings tab of each profile page for mapping ISO/IEEE 11073
 
 ### Mapping Details
 
+### Device Identification and Unique Device Identification (UDI)
+
+In ISO/IEEE 11073 SDC, the Medical Device System (MDS) provides detailed identification information through its descriptive state:
+- **ProductionSpecification** containing manufacturer and model information
+- **Identification** with Root (OID) and Extension providing globally unique device instance identification
+- **SerialNumber** of the device
+- **HardwareRevision** and **SoftwareRevision** providing version tracking
+
+These components map to FHIR Device resource elements for Unique Device Identification (UDI):
+
+| IEEE 11073 SDC Element | FHIR Device Mapping | Notes |
+| --- | --- | --- |
+| SystemContextDescriptor/ProductionSpecification/Manufacturer | `Device.manufacturer` | The device manufacturer name |
+| SystemContextDescriptor/ProductionSpecification/Model | `Device.modelNumber` | The device model designation |
+| Identification/Root (OID) | `Device.identifier.system` | The OID root identifies the namespace (e.g., manufacturer identifier) |
+| Identification/Extension | `Device.identifier.value` | The extension uniquely identifies the specific device instance |
+| SerialNumber | `Device.serialNumber` | The device's serial number, a critical component of UDI |
+| HardwareRevision | `Device.version` with `type`=`hardware-version` | Hardware revision level for device tracking |
+| SoftwareRevision | `Device.version` with `type`=`software-version` | Software/firmware revision level |
+| UDI structured data (where available) | `Device.udiCarrier` | FHIR provides structured storage of UDI barcodes and parsed UDI data |
+| UDI human-readable label | `Device.deviceName` with `type`=`udi-label-name` | The label name from the device's UDI label |
+{: .grid}
+
+**Implementation Guidance**:
+- SDC devices should provide comprehensive device identification through the ProductionSpecification and Identification attributes. This information should be translated to corresponding FHIR Device elements to support UDI requirements.
+- The combination of `Device.manufacturer`, `Device.modelNumber`, and `Device.serialNumber` forms the basis of device tracking and UDI compliance.
+- The `Device.identifier` with OID-based `system` preserves the IEEE 11073 device identification namespace, supporting interoperability with other IEEE 11073-based systems while mapping to FHIR.
+- When regulatory UDI information is available from the SDC source, it should be included in `Device.udiCarrier` for compliance tracking and supply chain management.
+
 #### Patient
 For each of the measurements Height and Weight, an Observation resource is required with mandatory data elements. `Observation.subject` shall be present and refer to a Patient resource or to an MDS Device resource.
 

--- a/input/pagecontent/mappingsdc.md
+++ b/input/pagecontent/mappingsdc.md
@@ -22,34 +22,27 @@ Please refer to the Mappings tab of each profile page for mapping ISO/IEEE 11073
 
 ### Mapping Details
 
-### Device Identification and Unique Device Identification (UDI)
+#### Device Identification and Unique Device Identification (UDI)
 
-In ISO/IEEE 11073 SDC, the Medical Device System (MDS) provides detailed identification information through its descriptive state:
-- **ProductionSpecification** containing manufacturer and model information
-- **Identification** with Root (OID) and Extension providing globally unique device instance identification
-- **SerialNumber** of the device
-- **HardwareRevision** and **SoftwareRevision** providing version tracking
+For SDC-to-FHIR UDI mapping in this guide, use the SDC elements that are mapped in the MDS Device profile:
 
-These components map to FHIR Device resource elements for Unique Device Identification (UDI):
-
-| IEEE 11073 SDC Element | FHIR Device Mapping | Notes |
-| --- | --- | --- |
-| SystemContextDescriptor/ProductionSpecification/Manufacturer | `Device.manufacturer` | The device manufacturer name |
-| SystemContextDescriptor/ProductionSpecification/Model | `Device.modelNumber` | The device model designation |
-| Identification/Root (OID) | `Device.identifier.system` | The OID root identifies the namespace (e.g., manufacturer identifier) |
-| Identification/Extension | `Device.identifier.value` | The extension uniquely identifies the specific device instance |
-| SerialNumber | `Device.serialNumber` | The device's serial number, a critical component of UDI |
-| HardwareRevision | `Device.version` with `type`=`hardware-version` | Hardware revision level for device tracking |
-| SoftwareRevision | `Device.version` with `type`=`software-version` | Software/firmware revision level |
-| UDI structured data (where available) | `Device.udiCarrier` | FHIR provides structured storage of UDI barcodes and parsed UDI data |
-| UDI human-readable label | `Device.deviceName` with `type`=`udi-label-name` | The label name from the device's UDI label |
+| IEEE 11073 SDC element (actual mapping source) | FHIR Device mapping |
+| --- | --- |
+| `MdsDescriptor/ProductionSpecification/ComponentId/Root` | `Device.identifier.system` (EUI-64 system) |
+| `MdsDescriptor/ProductionSpecification/ComponentId/Extension` | `Device.identifier.value` (EUI-64 value) |
+| `MdsDescriptor/MetaData/UDI/DeviceIdentifier` | `Device.udiCarrier.deviceIdentifier` |
+| `MdsDescriptor/MetaData/UDI/Issuer` | `Device.udiCarrier.issuer` |
+| `MdsDescriptor/MetaData/UDI/Jurisdictions` | `Device.udiCarrier.jurisdiction` (root + extension concatenation) |
+| `MdsDescriptor/MetaData/UDI/HumanReadableForm` | `Device.udiCarrier.carrierHRF` |
+| `MdsDescriptor/MetaData/SerialNumber` | `Device.serialNumber` |
+| `MdsDescriptor/MetaData/Manufacturer` | `Device.manufacturer` |
+| `MdsDescriptor/MetaData/ModelNumber` | `Device.modelNumber` |
 {: .grid}
 
 **Implementation Guidance**:
-- SDC devices should provide comprehensive device identification through the ProductionSpecification and Identification attributes. This information should be translated to corresponding FHIR Device elements to support UDI requirements.
-- The combination of `Device.manufacturer`, `Device.modelNumber`, and `Device.serialNumber` forms the basis of device tracking and UDI compliance.
-- The `Device.identifier` with OID-based `system` preserves the IEEE 11073 device identification namespace, supporting interoperability with other IEEE 11073-based systems while mapping to FHIR.
-- When regulatory UDI information is available from the SDC source, it should be included in `Device.udiCarrier` for compliance tracking and supply chain management.
+- For UDI carriage, prioritize `MdsDescriptor/MetaData/UDI/*` into `Device.udiCarrier.*`.
+- Keep `ComponentId/Root` + `ComponentId/Extension` mapped to `Device.identifier` for persistent device instance identity in parallel with UDI.
+- Preserve serial number mapping from `MdsDescriptor/MetaData/SerialNumber` to `Device.serialNumber` for traceability and device lifecycle workflows.
 
 #### Patient
 For each of the measurements Height and Weight, an Observation resource is required with mandatory data elements. `Observation.subject` shall be present and refer to a Patient resource or to an MDS Device resource.

--- a/input/pagecontent/mappingsdc.md
+++ b/input/pagecontent/mappingsdc.md
@@ -28,7 +28,7 @@ For SDC-to-FHIR UDI mapping in this guide, use the SDC elements that are mapped 
 
 | IEEE 11073 SDC element (actual mapping source) | FHIR Device mapping |
 | --- | --- |
-| `MdsDescriptor/ProductionSpecification/ComponentId/Root` | `Device.identifier.system` (EUI-64 system) |
+| `MdsDescriptor/ProductionSpecification/ComponentId/Root` | `Device.identifier.system` (fixed to `urn:oid:1.2.840.10004.1.1.1.0.0.1.0.0.1.2680`; Root should match) |
 | `MdsDescriptor/ProductionSpecification/ComponentId/Extension` | `Device.identifier.value` (EUI-64 value) |
 | `MdsDescriptor/MetaData/UDI/DeviceIdentifier` | `Device.udiCarrier.deviceIdentifier` |
 | `MdsDescriptor/MetaData/UDI/Issuer` | `Device.udiCarrier.issuer` |

--- a/input/pagecontent/mappingv2.md
+++ b/input/pagecontent/mappingv2.md
@@ -198,9 +198,9 @@ In PCD-01, UDI-related content is carried in OBX fields rather than in a dedicat
 | HL7 V2 PCD-01 Element | FHIR Device Mapping | Notes |
 | --- | --- | --- |
 | OBX-18 (EI: Equipment Instance Identifier) | `Device.identifier` | Carries the source equipment instance identifier (typically EUI-64 for VMD or MDS) |
-| OBX-3 (CWE: Observation Identifier) | `Device.udiCarrier.*` or `Device.serialNumber` | Identifies which device/production/UDI attribute is being conveyed |
+| OBX-3 (CWE: Observation Identifier) | Device element selector (e.g., `Device.udiCarrier.deviceIdentifier`, `Device.serialNumber`) | Identifies which UDI/production attribute is being conveyed (value carried in OBX-5) |
 | OBX-4 (ST: Observation Sub-ID) | `Device` target selection (MDS/VMD/Channel context) | Locates the device object in the PCD-01 containment hierarchy for the OBX attribute |
-| OBX-5 (Varies: Observation Value) | Value for the targeted `Device` element | Carries the actual attribute value (e.g., device identifier, issuer, jurisdiction, HRF label, serial number) |
+| OBX-5 (Varies: Observation Value) | Value for the selected `Device` element | Carries the actual attribute value (e.g., device identifier, issuer, jurisdiction, HRF label, serial number) |
 {: .grid}
 
 **Implementation Guidance for UDI**:

--- a/input/pagecontent/mappingv2.md
+++ b/input/pagecontent/mappingv2.md
@@ -193,23 +193,21 @@ In IHE PCD-01, the purpose of this field is to uniquely identify the source of t
 
 **Device Identification and UDI Mapping**: 
 
-The Equipment Instance Identifier in HL7 V2 PCD-01 messages maps to device identification elements in FHIR that support Unique Device Identification (UDI):
+In PCD-01, UDI-related content is carried in OBX fields rather than in a dedicated UDI segment. The actual message elements used are:
 
 | HL7 V2 PCD-01 Element | FHIR Device Mapping | Notes |
 | --- | --- | --- |
-| OBX-18 (EI: Equipment Instance Identifier) | `Device.identifier` | The unique identifier of the equipment (VMD or MDS) source of the observation |
-| EUI-64 format | `Device.identifier.system` + `Device.identifier.value` | When in EUI-64 format, map the authority to `system` and the identifier to `value` |
-| Device serial number (from sending system) | `Device.serialNumber` | Implement should extract and preserve the device serial number for UDI compliance |
-| Device model information | `Device.modelNumber` | The model of the equipment providing the source data |
-| UDI barcode data (when available) | `Device.udiCarrier` | Structured storage of parsed UDI data from device communications |
-| UDI human-readable label | `Device.deviceName` with `type`=`udi-label-name` | The label name from regulatory UDI labels, if known to the device or gateway |
+| OBX-18 (EI: Equipment Instance Identifier) | `Device.identifier` | Carries the source equipment instance identifier (typically EUI-64 for VMD or MDS) |
+| OBX-3 (CWE: Observation Identifier) | `Device.udiCarrier.*` or `Device.serialNumber` | Identifies which device/production/UDI attribute is being conveyed |
+| OBX-4 (ST: Observation Sub-ID) | `Device` target selection (MDS/VMD/Channel context) | Locates the device object in the PCD-01 containment hierarchy for the OBX attribute |
+| OBX-5 (Varies: Observation Value) | Value for the targeted `Device` element | Carries the actual attribute value (e.g., device identifier, issuer, jurisdiction, HRF label, serial number) |
 {: .grid}
 
 **Implementation Guidance for UDI**:
-- The Equipment Instance Identifier in OBX-18 identifies the specific equipment instance. This should be preserved in `Device.identifier` to maintain traceability to the source device.
-- When PCD-01 messages are converted to FHIR, the device serial number should be extracted (from OBX-18 context or other message segments) and placed in `Device.serialNumber`.
-- If the sending system has access to regulatory UDI information (barcode or parsed components), this should be included in `Device.udiCarrier.deviceIdentifier` (the GTIN/GTIN+UDI code).
-- Device gateways should populate `Device.type` with appropriate coding (e.g., MDC codes from the device communication) to enable systems to recognize and validate UDI compliance based on device regulatory classification.
+- Use OBX-18 to keep persistent equipment identity and create/update the corresponding `Device.identifier`.
+- For UDI-specific components, use device-related OBX observations where OBX-3 identifies the UDI/production attribute and OBX-5 carries the value.
+- Use OBX-4 Sub-ID to bind each device-related OBX to the correct device level (MDS or VMD) before mapping into the appropriate FHIR `Device` resource.
+- When OBX device-related attributes represent UDI device identifier, issuer, authority/jurisdiction, or human-readable label, map them to `Device.udiCarrier.deviceIdentifier`, `Device.udiCarrier.issuer`, `Device.udiCarrier.jurisdiction`, and `Device.udiCarrier.carrierHRF` respectively.
 
 
 #### OBX-20 Observation site

--- a/input/pagecontent/mappingv2.md
+++ b/input/pagecontent/mappingv2.md
@@ -191,6 +191,27 @@ The OBX-8 flags listed above do not all map directly to `Observation.interpretat
 
 In IHE PCD-01, the purpose of this field is to uniquely identify the source of the observation based on the EUI-64 of the Virtual Medical Device (VMD) if that has a unique identifier, or if not, the EUI-64 of the Medical Device System.
 
+**Device Identification and UDI Mapping**: 
+
+The Equipment Instance Identifier in HL7 V2 PCD-01 messages maps to device identification elements in FHIR that support Unique Device Identification (UDI):
+
+| HL7 V2 PCD-01 Element | FHIR Device Mapping | Notes |
+| --- | --- | --- |
+| OBX-18 (EI: Equipment Instance Identifier) | `Device.identifier` | The unique identifier of the equipment (VMD or MDS) source of the observation |
+| EUI-64 format | `Device.identifier.system` + `Device.identifier.value` | When in EUI-64 format, map the authority to `system` and the identifier to `value` |
+| Device serial number (from sending system) | `Device.serialNumber` | Implement should extract and preserve the device serial number for UDI compliance |
+| Device model information | `Device.modelNumber` | The model of the equipment providing the source data |
+| UDI barcode data (when available) | `Device.udiCarrier` | Structured storage of parsed UDI data from device communications |
+| UDI human-readable label | `Device.deviceName` with `type`=`udi-label-name` | The label name from regulatory UDI labels, if known to the device or gateway |
+{: .grid}
+
+**Implementation Guidance for UDI**:
+- The Equipment Instance Identifier in OBX-18 identifies the specific equipment instance. This should be preserved in `Device.identifier` to maintain traceability to the source device.
+- When PCD-01 messages are converted to FHIR, the device serial number should be extracted (from OBX-18 context or other message segments) and placed in `Device.serialNumber`.
+- If the sending system has access to regulatory UDI information (barcode or parsed components), this should be included in `Device.udiCarrier.deviceIdentifier` (the GTIN/GTIN+UDI code).
+- Device gateways should populate `Device.type` with appropriate coding (e.g., MDC codes from the device communication) to enable systems to recognize and validate UDI compliance based on device regulatory classification.
+
+
 #### OBX-20 Observation site
 This often does not need to be given, since in many cases the OBX-3 Observation Identifier clearly indicates the body site. Otherwise, in IHE PCD-01, body site values from MDC nomenclature may be used. Equivalent codes from other systems, e.g. SNOMED, should also be given in the CodeableConcept for user convenience.
 


### PR DESCRIPTION
- Add Device Identification and UDI mapping section to mappingdim.md with IEEE 11073 DIM element mappings
- Expand OBX-18 Equipment Instance Identifier section in mappingv2.md with UDI implementation guidance
- Add Device Identification and UDI mapping section to mappingsdc.md with ISO/IEEE 11073 SDC element mappings
- Include implementation guidance across all three standards for UDI compliance and traceability